### PR TITLE
Adiciona exemplo de falso positivo na captura das licitações de merenda

### DIFF
--- a/code/licitacoes/processa_licitacoes.R
+++ b/code/licitacoes/processa_licitacoes.R
@@ -50,11 +50,11 @@ filter_licitacoes_merenda <- function(licitacoes_df) {
     dplyr::mutate(DS_OBJETO_PROCESSED = iconv(DS_OBJETO, 
                                               from="UTF-8", 
                                               to="ASCII//TRANSLIT")) %>% 
-    # Filtra descrições relacionadas a alimentaçã
+    # Filtra descrições relacionadas a alimentação
     dplyr::mutate(isAlimentacao = grepl("^.*(genero.*aliment|aliment.*esc|genero.*agric.*famil|merenda|pnae).*$",
                                         tolower(DS_OBJETO_PROCESSED))) %>%
     # Remove casos em que o filtro foi muito abrangente (falsos positivos)
-    dplyr::mutate(falso_positivo = grepl("^((?!(fontes de|som|bivolt|copiad|magn|trator|impressora|roda)).)*$",
+    dplyr::mutate(falso_positivo = grepl("^((?!(fontes de|som|bivolt|copiad|magn|trator|impressora|roda|pnaest)).)*$",
                                         tolower(DS_OBJETO_PROCESSED),
                                         perl = TRUE)) %>%
     # considera apenas alimentação e filtra fora os falso positivos


### PR DESCRIPTION
## Mudanças
- Adiciona exemplo de falso positivo na captura das licitações de merenda. Palavra "PNAEST".