### PR TITLE
Adiciona unidade de medida à tabela de itens de contrato

### DIFF
--- a/code/utils/join_utils.R
+++ b/code/utils/join_utils.R
@@ -65,7 +65,8 @@ join_contrato_e_orgao <- function(contratos, orgao_municipio) {
 }
 
 join_itens_contratos_e_licitacoes <- function(itens_contratos, itens_licitacoes) {
-  itens_licitacoes %<>% dplyr::select(id_licitacao, id_item_licitacao = id_item, ds_item, nr_lote, nr_item)
+  itens_licitacoes %<>% dplyr::select(id_licitacao, id_item_licitacao = id_item, ds_item, 
+                                      nr_lote, nr_item, sg_unidade_medida)
   itens_contratos %<>% dplyr::left_join(itens_licitacoes) 
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ./code:/app/code
       - ./data:/app/data
+      - ./reports:/app/reports
     ports:
       - 8787:8787
     networks:

--- a/feed/scripts/create/create_item_contrato.sql
+++ b/feed/scripts/create/create_item_contrato.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS "item_contrato" (
     "vl_total_item_contrato" REAL,
     "dt_inicio_vigencia" DATE,
     "ds_item" VARCHAR(2000),
+    "sg_unidade_medida" VARCHAR(5),
     "categoria" INTEGER,
     "language" VARCHAR(15),
     "ds_1" VARCHAR(50),

--- a/feed/scripts/import/import_data.sql
+++ b/feed/scripts/import/import_data.sql
@@ -11,7 +11,7 @@ SET datestyle = ymd;
 
 CREATE MATERIALIZED VIEW item_search AS 
 SELECT o.nome_municipio, i.ano_licitacao, i.id_item_contrato, i.id_contrato, i.nr_contrato, i.dt_inicio_vigencia, i.id_licitacao, 
-    i.vl_item_contrato, i.vl_total_item_contrato, ds_item,
+    i.vl_item_contrato, i.vl_total_item_contrato, ds_item, i.sg_unidade_medida,
     setweight(to_tsvector(i.language :: regconfig,i.ds_1),'A') || 
     setweight(to_tsvector(i.language :: regconfig,i.ds_2),'C') || 
     setweight(to_tsvector(i.language :: regconfig,i.ds_3),'D') || 


### PR DESCRIPTION
## Mudanças
- Adiciona unidade de medida à tabela de itens de contrato
- Modifica view para conter unidade de medida dos itens
- Cria volume para diretório de reports (para facilitar execução de .Rmd usando o Rstudio contido na imagem R construída na arquitetura docker do projeto).