### PR TITLE
Adicionar processamento de fornecedores incluindo compras sem contrato

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,13 @@ help:
 	@echo "\t\t\t\t\tAssume um ou mais anos separados por vírgula. Assume que os dados foram baixados."	
 	@echo "\tprocess-data-empenhos \t\tExecuta o processamento de dados de empenhos."
 	@echo "\tprocess-data-novidades \t\tExecuta o processamento de dados de novidades."
-	@echo "\tprocess-data-fornecedores \t\tExecuta o processamento de dados de fornecedores."
+	@echo "\tprocess-data-fornecedores anos=<ano1,ano2> \t\tExecuta o processamento de dados de fornecedores."
 	@echo "\tfeed-create \t\t\tCria as tabelas usadas no Tá na Mesa no Banco de Dados."
 	@echo "\tfeed-import-data \t\tImporta dados dos CSV's (licitações e contratos) para o Banco de dados."
 	@echo "\tfeed-import-empenho \t\tImporta dados do CSV processado de empenhos para o Banco de dados."
 	@echo "\tfeed-import-empenho-raw \tImporta dados do CSV de dados brutos vindos do TCE."
 	@echo "\tfeed-import-novidade \t\tImporta dados do CSV processado de novidades para o Banco de dados."
+	@echo "\tfeed-update-fornecedores \t\tAtualiza dados do CSV processado de fornecedores para o Banco de dados."
 	@echo "\tfeed-shell \t\t\tAbre terminal psql com o banco cadastrado nas variáveis de ambiente."
 	@echo "\tfeed-clean-data \t\tRemove as tabelas processadas pelo Tá na Mesa (licitações, contratos e novidades)."
 	@echo "\tfeed-clean-empenho \t\tRemove as tabela de empenho (vinda do TCE) carregada no BD do Tá na Mesa."
@@ -40,7 +41,7 @@ process-data-novidades:
 	docker exec -it r-container sh -c "cd /app/code/processor && Rscript export_novidades_bd.R"
 .PHONY: process-data-novidades 
 process-data-fornecedores:		
-	docker exec -it r-container sh -c "cd /app/code/processor && Rscript export_fornecedores_bd.R"
+	docker exec -it r-container sh -c "cd /app/code/processor && Rscript export_fornecedores_bd.R $(anos)"
 .PHONY: process-data-fornecedores
 feed-create:	
 	docker exec -it feed python3.6 /feed/manage.py create

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo "\t\t\t\t\tAssume um ou mais anos separados por vírgula. Assume que os dados foram baixados."	
 	@echo "\tprocess-data-empenhos \t\tExecuta o processamento de dados de empenhos."
 	@echo "\tprocess-data-novidades \t\tExecuta o processamento de dados de novidades."
+	@echo "\tprocess-data-fornecedores \t\tExecuta o processamento de dados de fornecedores."
 	@echo "\tfeed-create \t\t\tCria as tabelas usadas no Tá na Mesa no Banco de Dados."
 	@echo "\tfeed-import-data \t\tImporta dados dos CSV's (licitações e contratos) para o Banco de dados."
 	@echo "\tfeed-import-empenho \t\tImporta dados do CSV processado de empenhos para o Banco de dados."
@@ -38,6 +39,9 @@ process-data-empenhos:
 process-data-novidades:		
 	docker exec -it r-container sh -c "cd /app/code/processor && Rscript export_novidades_bd.R"
 .PHONY: process-data-novidades 
+process-data-fornecedores:		
+	docker exec -it r-container sh -c "cd /app/code/processor && Rscript export_fornecedores_bd.R"
+.PHONY: process-data-fornecedores
 feed-create:	
 	docker exec -it feed python3.6 /feed/manage.py create
 .PHONY: feed-create
@@ -56,6 +60,9 @@ feed-import-novidade:
 feed-shell:	
 	docker exec -it feed python3.6 /feed/manage.py shell
 .PHONY: feed-shell
+feed-update-fornecedores:	
+	docker exec -it feed python3.6 /feed/manage.py update-fornecedores
+.PHONY: feed-update-fornecedores
 feed-clean-data:	
 	docker exec -it feed python3.6 /feed/manage.py clean-data
 .PHONY: feed-clean-data

--- a/code/contratos/processa_fornecedores.R
+++ b/code/contratos/processa_fornecedores.R
@@ -50,9 +50,19 @@ import_fornecedores_por_ano <- function(ano = 2019) {
 #' 
 #' Chave primária: 
 #' (nr_documento)
-processa_info_fornecedores <- function(fornecedores_df, contratos_df) {
+processa_info_fornecedores <- function(fornecedores_df, contratos_df, compras_df) {
   
-  fornecedores_info_geral <- contratos_df %>%
+  compras_df_sem_contratos <- compras_df %>% 
+    dplyr::mutate(id_orgao = as.character(id_orgao)) %>% 
+    dplyr::anti_join(contratos_df, 
+                     by = c("id_orgao", "nr_licitacao", "ano_licitacao",
+                            "cd_tipo_modalidade", "nr_contrato", "ano_contrato",
+                            "tp_instrumento_contrato"))
+  
+  contratos_geral_df <- contratos_df %>% 
+    dplyr::bind_rows(compras_df_sem_contratos)
+  
+  fornecedores_info_geral <- contratos_geral_df %>%
     dplyr::group_by(nr_documento_contratado) %>%
     dplyr::summarise(
       total_de_contratos = dplyr::n_distinct(
@@ -67,7 +77,7 @@ processa_info_fornecedores <- function(fornecedores_df, contratos_df) {
       data_primeiro_contrato = min(dt_inicio_vigencia, na.rm = TRUE)
     ) %>% 
     dplyr::ungroup()
-  
+
   info_fornecedores <- fornecedores_df %>%
     janitor::clean_names() %>% 
     dplyr::arrange(nm_pessoa) %>% 
@@ -76,9 +86,10 @@ processa_info_fornecedores <- function(fornecedores_df, contratos_df) {
                      tp_pessoa = dplyr::first(tp_pessoa)) %>% 
     dplyr::ungroup() %>% 
     ## Cruza com informações do fornecedor
-    dplyr::left_join(fornecedores_info_geral,
+    dplyr::full_join(fornecedores_info_geral,
                      by = c("nr_documento" = "nr_documento_contratado")) %>% 
-    dplyr::mutate(total_de_contratos = ifelse(is.na(total_de_contratos), 0, total_de_contratos))
+    dplyr::mutate(total_de_contratos = ifelse(is.na(total_de_contratos), 0, total_de_contratos)) %>% 
+    dplyr::filter(!is.na(nr_documento))
   
   return(info_fornecedores)
 }

--- a/code/empenhos/processa_empenhos.R
+++ b/code/empenhos/processa_empenhos.R
@@ -54,7 +54,7 @@ processa_info_empenhos <- function(empenhos_df) {
                                  nome_orgao_orcamentario, cd_unidade_orcamentaria, nome_unidade_orcamentaria, tp_unidade, 
                                  tipo_operacao, ano_empenho, ano_operacao, 
                                  dt_empenho, dt_operacao, nr_empenho, historico, cd_funcao, ds_funcao, cd_subfuncao, ds_subfuncao, cd_programa, 
-                                 ds_programa, cd_projeto, nm_projeto, cd_recurso, nm_recurso, cd_credor, nm_credor, cnpj_cpf, vl_empenho, 
+                                 ds_programa, cd_projeto, nm_projeto, cd_recurso, nm_recurso, cd_credor, nm_credor, tp_pessoa, cnpj_cpf, vl_empenho, 
                                  nr_liquidacao, vl_liquidacao, nr_pagamento, vl_pagamento, ano_licitacao, nr_licitacao, 
                                  cd_tipo_modalidade = mod_licitacao, ano_contrato, nr_contrato, 
                                  tp_instrumento_contrato = tp_instrumento_contratual

--- a/code/processor/export_dados_bd.R
+++ b/code/processor/export_dados_bd.R
@@ -127,17 +127,6 @@ info_contratos <-
                      "nr_contrato", "ano_contrato", "tp_instrumento_contrato"), CONTRATO_ID) %>% 
   dplyr::select(id_contrato, id_licitacao, id_orgao, dplyr::everything())
 
-## Fornecedores nos contratos
-message("#### fornecedores (contratos)...")
-source(here("code/contratos/processa_fornecedores.R"))
-
-info_fornecedores_contratos <- import_fornecedores(anos) %>% 
-  processa_info_fornecedores(contratos) %>% 
-  join_contratos_e_fornecedores(info_contratos %>% 
-                                  dplyr::select(nr_documento_contratado)) %>% 
-  dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
-  dplyr::select(nr_documento, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
-
 ## Itens de contratos
 message("#### itens de contratos...")
 source(here("code/contratos/processa_itens_contrato.R"))
@@ -194,6 +183,17 @@ info_item_contrato <- itens_comprados %>%
   dplyr::select(id_item_contrato, id_contrato, id_orgao, id_licitacao, id_item_licitacao, dplyr::everything()) %>% 
   create_categoria() %>%
   split_descricao()
+
+## Fornecedores nos contratos
+message("#### fornecedores (contratos)...")
+source(here("code/contratos/processa_fornecedores.R"))
+
+info_fornecedores_contratos <- import_fornecedores(anos) %>% 
+  processa_info_fornecedores(contratos, info_contratos) %>% 
+  join_contratos_e_fornecedores(info_contratos %>% 
+                                  dplyr::select(nr_documento_contratado)) %>% 
+  dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
+  dplyr::select(nr_documento, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
 
 ## Alterações contratos
 message("#### alterações de contratos...")

--- a/code/processor/export_fornecedores_bd.R
+++ b/code/processor/export_fornecedores_bd.R
@@ -1,0 +1,29 @@
+library(magrittr)
+
+help <- "
+Usage:
+Rscript export_fornecedores_bd.R
+"
+source(here::here("code/contratos/processa_fornecedores.R"))
+source(here::here("code/utils/read_utils.R"))
+
+empenhos_df <- read_empenhos_processados()
+compras_df <- read_contratos_processados()
+
+compras_atualizadas <- processa_fornecedores_compras(empenhos_df, compras_df)
+
+print("Atualizando dados de fornecedores...")
+contratos <- import_contratos(anos) %>% 
+  processa_info_contratos()
+
+info_fornecedores_contratos <- import_fornecedores(anos) %>% 
+  processa_info_fornecedores(contratos) %>% 
+  join_contratos_e_fornecedores(compras_atualizadas %>% 
+                                  dplyr::select(nr_documento_contratado)) %>% 
+  dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
+  dplyr::select(nr_documento, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
+
+readr::write_csv(compras_atualizadas, here("data/bd/info_contrato.csv"))
+readr::write_csv(info_fornecedores_contratos, here("data/bd/info_fornecedores_contrato.csv"))
+
+print("Concluído!")

--- a/code/processor/export_fornecedores_bd.R
+++ b/code/processor/export_fornecedores_bd.R
@@ -1,11 +1,25 @@
+library(tidyverse)
 library(magrittr)
 
 help <- "
 Usage:
-Rscript export_fornecedores_bd.R
+Rscript export_fornecedores_bd.R <anos>
+<anos> pode ser um ano (2017) ou múltiplos anos separados por vírgula (2017,2018,2019)
 "
+
+args <- commandArgs(trailingOnly = TRUE)
+min_num_args <- 1
+if (length(args) < min_num_args) {
+  stop(paste("Wrong number of arguments!", help, sep = "\n"))
+}
+
+anos <- unlist(strsplit(args[1], split=","))
+# anos = c(2018, 2019, 2020)
+
+source(here::here("code/contratos/processa_contratos.R"))
 source(here::here("code/contratos/processa_fornecedores.R"))
 source(here::here("code/utils/read_utils.R"))
+source(here::here("code/utils/join_utils.R"))
 
 empenhos_df <- read_empenhos_processados()
 compras_df <- read_contratos_processados()
@@ -23,7 +37,17 @@ info_fornecedores_contratos <- import_fornecedores(anos) %>%
   dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
   dplyr::select(nr_documento, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
 
-readr::write_csv(compras_atualizadas, here("data/bd/info_contrato.csv"))
-readr::write_csv(info_fornecedores_contratos, here("data/bd/info_fornecedores_contrato.csv"))
+fornecedores_extra_sem_contratos <- compras_atualizadas %>% 
+  dplyr::filter(!nr_documento_contratado %in% (info_fornecedores_contratos %>% 
+                                                dplyr::pull(nr_documento))) %>% 
+  dplyr::filter(!is.na(nr_documento_contratado)) %>% 
+  dplyr::distinct(nr_documento_contratado) %>% 
+  dplyr::select(nr_documento = nr_documento_contratado)
+
+info_fornecedores_contratos <- info_fornecedores_contratos %>% 
+  dplyr::bind_rows(fornecedores_extra_sem_contratos)
+
+readr::write_csv(compras_atualizadas, here::here("data/bd/info_contrato.csv"))
+readr::write_csv(info_fornecedores_contratos, here::here("data/bd/info_fornecedores_contrato.csv"))
 
 print("Concluído!")

--- a/code/processor/export_fornecedores_bd.R
+++ b/code/processor/export_fornecedores_bd.R
@@ -31,21 +31,12 @@ contratos <- import_contratos(anos) %>%
   processa_info_contratos()
 
 info_fornecedores_contratos <- import_fornecedores(anos) %>% 
-  processa_info_fornecedores(contratos) %>% 
+  processa_info_fornecedores(contratos, compras_atualizadas) %>% 
   join_contratos_e_fornecedores(compras_atualizadas %>% 
                                   dplyr::select(nr_documento_contratado)) %>% 
   dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
   dplyr::select(nr_documento, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
 
-fornecedores_extra_sem_contratos <- compras_atualizadas %>% 
-  dplyr::filter(!nr_documento_contratado %in% (info_fornecedores_contratos %>% 
-                                                dplyr::pull(nr_documento))) %>% 
-  dplyr::filter(!is.na(nr_documento_contratado)) %>% 
-  dplyr::distinct(nr_documento_contratado) %>% 
-  dplyr::select(nr_documento = nr_documento_contratado)
-
-info_fornecedores_contratos <- info_fornecedores_contratos %>% 
-  dplyr::bind_rows(fornecedores_extra_sem_contratos)
 
 readr::write_csv(compras_atualizadas, here::here("data/bd/info_contrato.csv"))
 readr::write_csv(info_fornecedores_contratos, here::here("data/bd/info_fornecedores_contrato.csv"))

--- a/feed/manage.py
+++ b/feed/manage.py
@@ -44,6 +44,12 @@ def update_data():
     subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/update/update_novidade.sql'])
 
 @click.command()
+def update_fornecedores():
+    """Atualiza as tabelas do Banco de Dados"""
+    subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/update/update_fornecedor.sql'])
+    subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/update/update_contrato.sql'])
+
+@click.command()
 def import_data():
     """Importa dados para as tabelas do Banco de dados"""
     subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/import/import_data.sql'])
@@ -73,7 +79,6 @@ def clean_data():
     """Dropa as tabelas do Banco de Dados"""
     subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/drop/drop_tables.sql'])
 
-
 @click.command()
 def shell():
     """Acessa terminal do banco de dados"""
@@ -82,6 +87,7 @@ def shell():
 
 cli.add_command(create)
 cli.add_command(update_data)
+cli.add_command(update_fornecedores)
 cli.add_command(import_data)
 cli.add_command(import_empenho)
 cli.add_command(import_novidade)

--- a/feed/scripts/create/create_empenho.sql
+++ b/feed/scripts/create/create_empenho.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS "empenho" (
     "nm_recurso" VARCHAR(240),
     "cd_credor" VARCHAR(240),
     "nm_credor" VARCHAR(240),
+    "tp_pessoa" VARCHAR(2),
     "cnpj_cpf" VARCHAR(14),
     "vl_empenho" REAL,
     "nr_liquidacao" VARCHAR(40),

--- a/feed/scripts/update/update_contrato.sql
+++ b/feed/scripts/update/update_contrato.sql
@@ -7,7 +7,7 @@ CREATE TEMP TABLE temp_contrato AS SELECT * FROM contrato LIMIT 0;
 INSERT INTO contrato 
 SELECT *
 FROM temp_contrato
-ON CONFLICT (id_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, nr_contrato, ano_contrato, tp_instrumento_contrato)
+ON CONFLICT (id_contrato)
 DO
   UPDATE
   SET  

--- a/feed/scripts/update/update_fornecedor.sql
+++ b/feed/scripts/update/update_fornecedor.sql
@@ -13,8 +13,8 @@ DO
   SET  
     nm_pessoa = EXCLUDED.nm_pessoa,
     tp_pessoa = EXCLUDED.tp_pessoa,
-    total_de_contratos = EXCLUDED.nm_pessoa,
-    data_primeiro_contrato = EXCLUDED.nm_pessoa;
+    total_de_contratos = EXCLUDED.total_de_contratos,
+    data_primeiro_contrato = EXCLUDED.data_primeiro_contrato;
 
 DROP TABLE temp_fornecedor;
 COMMIT;

--- a/feed/scripts/update/update_fornecedor.sql
+++ b/feed/scripts/update/update_fornecedor.sql
@@ -12,7 +12,9 @@ DO
   UPDATE
   SET  
     nm_pessoa = EXCLUDED.nm_pessoa,
-    tp_pessoa = EXCLUDED.tp_pessoa;
+    tp_pessoa = EXCLUDED.tp_pessoa,
+    total_de_contratos = EXCLUDED.nm_pessoa,
+    data_primeiro_contrato = EXCLUDED.nm_pessoa;
 
 DROP TABLE temp_fornecedor;
 COMMIT;

--- a/update-data.sh
+++ b/update-data.sh
@@ -59,10 +59,16 @@ run_data_process_update() {
     pprint "9. Processa dados de novidades"
     docker exec r-container sh -c "cd /app/code/processor && Rscript export_novidades_bd.R"
 
-    pprint "10. Importa dados de empenhos para o BD"
+    pprint "10. Atualiza dados de fornecedores"
+    docker exec r-container sh -c "cd /app/code/processor && Rscript export_fornecedores_bd.R"
+
+    pprint "11. Importa dados de fornecedores e contratos para o BD"
+    docker exec feed python3.6 /feed/manage.py update-fornecedores
+
+    pprint "12. Importa dados de empenhos para o BD"
     docker exec feed python3.6 /feed/manage.py import-empenho
 
-    pprint "11. Importa dados de novidades para o BD"
+    pprint "13. Importa dados de novidades para o BD"
     docker exec feed python3.6 /feed/manage.py import-novidade
 
 }


### PR DESCRIPTION
## Mudanças
- Adiciona passo ao pipeline que processa as informações dos fornecedores ligados a compras sem contrato

## Flags
- Os dados processados gerados por esta versão estão disponíveis aqui para o filtro covid:
https://drive.google.com/file/d/1uDb6eXkey5KHmsCil3y4D7BbK_l3kk75/view?usp=sharing
- Existe a possibilidade de uma compra sem contrato está ligada a mais de um fornecedor. Neste caso, foi ignorado os demais fornecedores e mantido apenas o primeiro. Posteriormente será necessário criar uma nova relação no banco de dados entre compras e fornecedores (1 para n), de forma a lidar com esses casos. (211 compras estão associadas a mais de um fornecedor nos empenhos)
