### PR TITLE
Refatora módulo de alertas para permitir processamento por estado

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "\tprocess-data-novidades \t\tExecuta o processamento de dados de novidades."
 	@echo "\tprocess-data-fornecedores anos=<ano1,ano2> \t\tExecuta o processamento de dados de fornecedores."
 	@echo "\tprocess-data-itens-similares \t\tExecuta o processamento para agrupar itens similares."
-	@echo "\tprocess-data-alertas anos=<ano1,ano2> filtro=<merenda> \t\tExecuta o processamento de dados dos Alertas."
+	@echo "\tprocess-data-alertas anos=<ano1,ano2> filtro=<merenda> estados=<RS,PE,BR> \t\tExecuta o processamento de dados dos Alertas."
 	@echo "\tfeed-create \t\t\tCria as tabelas usadas no Tá na Mesa no Banco de Dados."
 	@echo "\tfeed-create-empenho-raw \t\t\tCria a tabela de empenho raw usada para processamento de empenhos."
 	@echo "\tfeed-create-empenho-raw-gov-federal \t\t\tCria as tabelas de empenho e itens de empenhos usada para processamento de empenhos do Governo Federal."
@@ -70,7 +70,7 @@ process-data-itens-similares:
 	docker exec r-container sh -c "cd /app/transformer/processor/geral/alertas && Rscript export_itens_similares.R"
 .PHONY: process-data-itens-similares
 process-data-alertas:
-	docker exec r-container sh -c "cd /app/transformer/processor/geral/alertas && Rscript export_alertas_bd.R $(anos) $(filtro)"
+	docker exec r-container sh -c "cd /app/transformer/processor/geral/alertas && Rscript export_alertas_bd.R $(anos) $(filtro) $(estados)"
 .PHONY: process-data-alertas
 feed-create:
 	docker-compose run --rm --no-deps feed python3.6 /feed/manage.py create

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ make process-data-itens-similares
 Processe os dados de alertas referentes a fornecedores contratados logo após a abertura da empresa:
 
 ```shell
-make process-data-alertas anos=2018,2019,2020,2021 filtro=merenda
+make process-data-alertas anos=2018,2019,2020,2021 filtro=merenda estados=RS,PE,BR
 ```
 
 Os dados processados de alertas estarão disponíveis no diretório `data/bd`.

--- a/transformer/adapter/estados/Federal/contratos/adaptador_compras_federal.R
+++ b/transformer/adapter/estados/Federal/contratos/adaptador_compras_federal.R
@@ -84,7 +84,7 @@ adapta_info_compras_federal <- function(empenho_df, empenhos_licitacao_df, filtr
     mutate(tp_instrumento_contrato = "Compra",
            tipo_instrumento_contrato = "Compra",
            contrato_possui_garantia = NA_character_,
-           vigencia_original_do_contrato = NA_character_,
+           vigencia_original_do_contrato = NA_integer_,
            justificativa_contratacao = NA_character_,
            data = as.Date(data_emissao, format = "%d/%m/%Y"),
            ano_contrato = lubridate::year(data),

--- a/transformer/processor/aggregator/agrega_contratos.R
+++ b/transformer/processor/aggregator/agrega_contratos.R
@@ -1,22 +1,93 @@
 library(tidyverse)
 source(here::here("transformer/utils/utils.R"))
+source(here::here("transformer/adapter/estados/PE/licitacoes/adaptador_licitacoes_pe.R"))
 source(here::here("transformer/processor/estados/PE/contratos/processador_contratos_pe.R"))
 source(here::here("transformer/processor/estados/RS/contratos/processador_contratos_rs.R"))
+source(here::here("transformer/processor/estados/Federal/contratos/processador_compras_federal.R"))
+source(here::here("transformer/processor/estados/Federal/licitacoes/processador_licitacoes_federal.R"))
 
 #' Agrupa todos os contratos dos estados disponíveis na plataforma Tá de pé
 #' 
 #' @param anos Array com os anos para recuperação dos contratos. Exemplo: c(2018, 2019, 2020)
+#' @param estados Array com os estados para considerar nos contratos
 #' @return Dataframe os contratos agregados
 #' 
 #' @examples 
-#' contratos <- agrega_contratos(c(2018, 2019, 2020))
-agrega_contratos <- function(anos) {
-  contratos_rs <- processa_contratos_rs(anos)
+#' contratos <- agrega_contratos(c(2018, 2019, 2020), c("RS", "PE", "BR"))
+agrega_contratos <- function(anos, estados = c("RS", "PE", "BR")) {
   
-  contratos_pe <- processa_contratos_pe()
+  if ("RS" %in% estados) {
+    contratos_rs <- tryCatch({
+      flog.info("# processando contratos do RS...")
+      processa_contratos_rs(anos)
+    }, error = function(e) {
+      flog.error("Ocorreu um erro ao processar os dados de contratos do RS")
+      flog.error(e)
+      return(tibble())
+    })
+  } else {
+    contratos_rs <- tibble()
+  }
   
-  todos_contratos <- contratos_rs %>% 
-    bind_rows(contratos_pe) %>%
+  if ("PE" %in% estados) {
+    contratos_pe <- tryCatch({
+      flog.info("# processando contratos do PE...")
+      contratos_raw <- processa_contratos_pe()
+      licitacoes_raw <- import_licitacoes_pe() %>%
+        janitor::clean_names() %>% 
+        select(
+          nr_licitacao = codigo_pl,
+          cd_orgao = codigo_ug,
+          ano_licitacao = ano_processo,
+          cd_tipo_modalidade = codigo_modalidade
+        ) %>%
+        add_info_estado("PE", "26") %>% 
+        distinct(cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, id_estado)
+      
+      contratos_merge <- contratos_raw %>% 
+        dplyr::inner_join(licitacoes_raw, by = c("cd_orgao", "nr_licitacao", "id_estado"))
+    }, error = function(e) {
+      flog.error("Ocorreu um erro ao processar os dados de contratos do PE")
+      flog.error(e)
+      return(tibble())
+    })
+  } else {
+    contratos_pe <- tibble()
+  }
+  
+  if ("BR" %in% estados) {
+    contratos_federais <- tryCatch({
+      flog.info("# processando contratos do BR...")
+      compras_raw <- processa_compras_federal()
+      licitacoes_raw <- processa_licitacoes_federal()
+      
+      compras_federais <- compras_raw %>%
+        dplyr::left_join(
+          licitacoes_raw %>%
+            dplyr::select(cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, id_estado) %>% 
+            filter(id_estado == "99"),
+          by = c(
+            "cd_orgao_lic" = "cd_orgao",
+            "nr_licitacao",
+            "cd_tipo_modalidade",
+            "id_estado"
+          )
+        )
+    }, error = function(e) {
+      flog.error("Ocorreu um erro ao processar os dados de contratos do BR")
+      flog.error(e)
+      return(tibble())
+    })
+  } else {
+    contratos_federais <- tibble()
+  }
+  
+  if (nrow(contratos_rs) == 0 && nrow(contratos_pe) == 0 && nrow(contratos_federais) == 0) {
+    flog.warn("Nenhum dado de contrato para agregar")
+    return(tibble())
+  }
+  
+  todos_contratos <- bind_rows(contratos_rs, contratos_pe, contratos_federais) %>%
     select(id_estado, cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, 
            nr_contrato, ano_contrato, tp_instrumento_contrato,
            nm_orgao, nr_documento_contratado, dt_inicio_vigencia, vl_contrato, descricao_objeto_contrato)

--- a/transformer/processor/estados/Federal/licitacoes/processador_licitacoes_federal.R
+++ b/transformer/processor/estados/Federal/licitacoes/processador_licitacoes_federal.R
@@ -7,7 +7,7 @@ source(here::here("transformer/adapter/estados/Federal/licitacoes/adaptador_lici
 #' 
 #' @examples 
 #' licitacoes_federais <- processa_licitacoes_federal()
-processa_licitacoes_federal <- function(filtro) {
+processa_licitacoes_federal <- function(filtro = "covid") {
   licitacoes_federais <- import_licitacoes_federal() %>% 
     adapta_info_licitacoes_federal(filtro) %>%
     add_info_estado(sigla_estado = "BR", id_estado = "99") 

--- a/transformer/processor/geral/alertas/data/limite_itens_estados.csv
+++ b/transformer/processor/geral/alertas/data/limite_itens_estados.csv
@@ -1,3 +1,4 @@
 id_estado,limite_minimo_itens
 26,30
 43,250
+99,30

--- a/transformer/processor/geral/alertas/export_alertas_bd.R
+++ b/transformer/processor/geral/alertas/export_alertas_bd.R
@@ -6,17 +6,17 @@ source(here::here("transformer/utils/rollbar.R"))
 
 help <- "
 Usage:
-Rscript export_alertas_bd.R <anos> <filtro>
+Rscript export_alertas_bd.R <anos> <filtro> <estados>
 <anos> pode ser um ano (2017) ou múltiplos anos separados por vírgula (2017,2018,2019)
 <filtro> pode ser merenda ou covid
 Exemplos:
-Rscript export_alertas_bd.R 2019 merenda
-Rscript export_alertas_bd.R 2018,2019,2020 merenda
+Rscript export_alertas_bd.R 2019 merenda BR
+Rscript export_alertas_bd.R 2018,2019,2020 merenda RS,PE,BR
 Certifique-se que os dados do TCE para os anos correspondentes foram baixados (Leia o README)
 "
 
 args <- commandArgs(trailingOnly = TRUE)
-min_num_args <- 2
+min_num_args <- 3
 if (length(args) < min_num_args) {
   stop(paste("Wrong number of arguments!", help, sep = "\n"))
 }
@@ -25,6 +25,8 @@ anos <- unlist(strsplit(args[1], split=","))
 # anos = c(2018, 2019, 2020, 2021)
 filtro <- args[2]
 # filtro <- "merenda"
+estados <- unlist(strsplit(args[3], split=","))
+# estados <- c("BR", "RS", "PE")
 
 source(here::here("transformer/utils/utils.R"))
 source(here::here("transformer/utils/read_utils.R"))
@@ -39,9 +41,9 @@ flog.info("Criando alertas...")
 
 tipos_alerta <- create_tipo_alertas()
 
-alertas_data <- processa_alertas_data_abertura_contrato(anos)
+alertas_data <- processa_alertas_data_abertura_contrato(anos, estados)
 alertas_cnae_atipico_item <- processa_alerta_cnae_atipico(filtro)
-alertas_empresas_inidoneas <- processa_alerta_inidoneas(anos)
+alertas_empresas_inidoneas <- processa_alerta_inidoneas(anos, estados)
 alertas_faturamento_suspeito <- processa_alerta_faturamento_suspeito()
 
 alertas <- bind_rows(alertas_data, 

--- a/transformer/processor/geral/alertas/functions/helpers/processa_contratos_info.R
+++ b/transformer/processor/geral/alertas/functions/helpers/processa_contratos_info.R
@@ -7,11 +7,12 @@ source(here::here("transformer/processor/aggregator/agrega_contratos.R"))
 #' Os contratos considerados independem do assunto (filtro), já as compras consideradas envolvem apenas contratos do assunto. 
 #' 
 #' @param anos Array com os anos para recuperação dos contratos. Exemplo: c(2018, 2019, 2020)
+#' @param estados Array com os estados para considerar nos contratos
 #' @return Dataframe com alertas para a diferença de daras
 #' 
 #' @examples 
-#' contratos_merge <- processa_contratos_info(c(2018, 2019, 2020))
-processa_contratos_info <- function(anos) {
+#' contratos_merge <- processa_contratos_info(c(2018, 2019, 2020), c("RS", "PE", "BR"))
+processa_contratos_info <- function(anos, estados = c("RS", "PE", "BR")) {
   contratos_processados <- read_contratos_processados() %>% 
     mutate(id_orgao = as.character(id_orgao)) %>% 
     select(id_contrato, id_estado, id_orgao, cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, 
@@ -19,7 +20,7 @@ processa_contratos_info <- function(anos) {
            nm_orgao, nr_documento_contratado, dt_inicio_vigencia, vl_contrato, 
            descricao_objeto_contrato)
 
-  todos_contratos <- agrega_contratos(anos)
+  todos_contratos <- agrega_contratos(anos, estados)
   
   contratos_merge <- contratos_processados %>% 
     bind_rows(todos_contratos) %>% 

--- a/transformer/processor/geral/alertas/functions/processa_alerta_data_abertura.R
+++ b/transformer/processor/geral/alertas/functions/processa_alerta_data_abertura.R
@@ -10,11 +10,12 @@ source(here::here("transformer/processor/aggregator/agrega_contratos.R"))
 #' Processa alertas de fornecedores com relação a diferença entre a data de abertura e a data do primeiro contrato
 #' 
 #' @param anos Array com os anos para recuperação dos contratos. Exemplo: c(2018, 2019, 2020)
+#' @param estados Array com os estados para considerar nos contratos
 #' @return Dataframe com alertas para a diferença de datas
 #' 
 #' @examples 
-#' alertas <- processa_alertas_data_abertura_contrato(c(2018, 2019, 2020))
-processa_alertas_data_abertura_contrato <- function(anos) {
+#' alertas <- processa_alertas_data_abertura_contrato(c(2018, 2019, 2020), c("RS", "PE", "BR"))
+processa_alertas_data_abertura_contrato <- function(anos, estados = c("RS", "PE", "BR")) {
   flog.info(str_glue("Processando alertas da data de abertura!"))
   LIMITE_DIFERENCA_DIAS = 30
   flog.info(str_glue("Diferença de dias entre a abertura e o primeiro contrato: {LIMITE_DIFERENCA_DIAS}"))
@@ -33,7 +34,7 @@ processa_alertas_data_abertura_contrato <- function(anos) {
   
   flog.info(str_glue("{fornecedores %>% nrow()} fornecedores com o alerta!"))
   
-  contratos_merge <- processa_contratos_info(anos)
+  contratos_merge <- processa_contratos_info(anos, estados)
   flog.info(str_glue("Pesquisa feita em {contratos_merge %>% nrow()} contratos de {contratos_merge %>% count(id_estado) %>% nrow()} estados."))
   
   fornecedores_contratos <- fornecedores %>% 
@@ -41,6 +42,7 @@ processa_alertas_data_abertura_contrato <- function(anos) {
                                       "data_primeiro_contrato" = "dt_inicio_vigencia"))
   
   alertas_data <- fornecedores_contratos %>% 
+    filter(!is.na(nr_contrato)) %>% 
     mutate(id_tipo = 1) %>% 
     mutate(info = paste0("Contrato ", nr_contrato, "/", ano_contrato, " em ", nm_orgao)) %>% 
     select(nr_documento, id_contrato, id_tipo, info) %>% 
@@ -50,6 +52,3 @@ processa_alertas_data_abertura_contrato <- function(anos) {
   
   return(alertas_data)
 }
-
-
-

--- a/transformer/processor/geral/alertas/functions/processa_alerta_inidoneas.R
+++ b/transformer/processor/geral/alertas/functions/processa_alerta_inidoneas.R
@@ -6,10 +6,11 @@ source(here::here("transformer/processor/geral/alertas/functions/helpers/process
 
 #' @title Gera alertas para empresas inidoneas
 #' @description Gera alertas para empresas inidoneas que estão presentes na lista de fornecedores
-#' @param Anos para consideração dos contratos feitos com fornecedores sancionados. 
+#' @param Anos para consideração dos contratos feitos com fornecedores sancionados.
+#' @param estados Array com os estados para considerar nos contratos
 #' Array com os anos para recuperação dos contratos. Exemplo: c(2018, 2019, 2020)
 #' @return Dataframe com os alertas gerados
-processa_alerta_inidoneas <- function(anos) {
+processa_alerta_inidoneas <- function(anos, estados = c("RS", "PE", "BR")) {
   flog.info("Processando alertas de empresas inidôneas...")
   
   ceis <- read_csv(here::here("data/inidoneos/ceis.csv"), col_types = cols(.default = col_character())) %>% 
@@ -25,7 +26,7 @@ processa_alerta_inidoneas <- function(anos) {
   
   fornecedores <- read_fornecedores_processados()
   
-  contratos_merge <- processa_contratos_info(anos) %>% 
+  contratos_merge <- processa_contratos_info(anos, estados) %>% 
     distinct(id_contrato, nr_contrato, nr_documento_contratado, dt_inicio_vigencia)
   
   fornecedores_inidoneos <- fornecedores %>% 

--- a/transformer/utils/read_utils.R
+++ b/transformer/utils/read_utils.R
@@ -268,7 +268,8 @@ read_dados_cadastrais_processados <- function() {
                                       col_types = list(
                                         cnpj = col_character(),
                                         data_situacao_especial = col_character(),
-                                        situacao_especial = col_character()
+                                        situacao_especial = col_character(),
+                                        cnae_fiscal = col_character()
                                         ))
 }
 

--- a/update-data.sh
+++ b/update-data.sh
@@ -218,7 +218,7 @@ process_data_alertas(){
   echo ""
   printWithTime "> Executando o processamento de alertas"
   echo ""
-  make process-data-alertas anos=$1 filtro=$2
+  make process-data-alertas anos=$1 filtro=$2 estados=$3
 }   
 
 # ==============================================================
@@ -360,7 +360,7 @@ for tipoAplicacao in "${tiposAplicacao[@]}"; do
   process_data_itens_similares
 
   # Processa os dados de alertas referentes a fornecedores contratados logo após a abertura da empresa:
-  process_data_alertas $anosConcatenados "$tipoAplicacao"
+  process_data_alertas $anosConcatenados "$tipoAplicacao" "$ESTADOS"
 
   # Importa os dados de empenhos processados para o BD
   feed_import_empenho


### PR DESCRIPTION
## Mudanças
- Refatora módulo de alertas para permitir processamento por estado
- Permite processamento da malha fina com os dados federais

Para executar a nova versão do processamento de alertas faça:
```
make process-data-alertas anos=2018,2019,2020,2021 filtro=covid estados=BR
```
